### PR TITLE
Setting for active moon phase

### DIFF
--- a/src/main/java/lumien/bloodmoon/config/BloodmoonConfig.java
+++ b/src/main/java/lumien/bloodmoon/config/BloodmoonConfig.java
@@ -71,9 +71,13 @@ public class BloodmoonConfig
 		@Comment(value = { "The chance of a bloodmoon occuring at the beginning of a night (0=Never;1=Every night;0.05=5% of all nights)" })
 		public double CHANCE = 0.05;
 
-		@Name(value = "Fullmoon")
-		@Comment(value = { "Whether there should be a bloodmoon whenever there is a full moon" })
-		public boolean FULLMOON = false;
+		@Name(value = "PhaseDependant")
+		@Comment(value = { "The bloodmoon depends on the phase set in the Phase setting" })
+		public boolean PHASE_DEPENDANT = true;
+
+		@Name(value = "Phase")
+		@Comment(value = { "Range from 0 to 7 (0 = Full Moon, 4 = New Moon)" })
+		public int PHASE_NUM = 0;
 
 		@Name(value = "NthNight")
 		@Comment(value = { "Every nth night there will be a bloodmoon (0 disables this, 1 would be every night, 2 every second night)" })

--- a/src/main/java/lumien/bloodmoon/server/BloodmoonHandler.java
+++ b/src/main/java/lumien/bloodmoon/server/BloodmoonHandler.java
@@ -1,5 +1,6 @@
 package lumien.bloodmoon.server;
 
+import lumien.bloodmoon.Bloodmoon;
 import lumien.bloodmoon.config.BloodmoonConfig;
 import lumien.bloodmoon.network.PacketHandler;
 import lumien.bloodmoon.network.messages.MessageBloodmoonStatus;
@@ -61,7 +62,8 @@ public class BloodmoonHandler extends WorldSavedData
 			World world = event.world;
 			if (world.provider.getDimension() == 0)
 			{
-				int time = (int) (world.getWorldTime() % 24000);
+				long wt = world.getWorldTime();
+				int time = (int) (wt % 24000);
 				if (isBloodmoonActive())
 				{
 					if (!BloodmoonConfig.GENERAL.RESPECT_GAMERULE || world.getGameRules().getBoolean("doMobSpawning"))
@@ -92,8 +94,7 @@ public class BloodmoonHandler extends WorldSavedData
 
 							this.markDirty();
 						}
-
-						if (forceBloodMoon || Math.random() < BloodmoonConfig.SCHEDULE.CHANCE || (BloodmoonConfig.SCHEDULE.FULLMOON && world.getCurrentMoonPhaseFactor() == 1.0F) || (BloodmoonConfig.SCHEDULE.NTH_NIGHT != 0 && nightCounter == 0))
+						if (forceBloodMoon || Math.random() < BloodmoonConfig.SCHEDULE.CHANCE || (BloodmoonConfig.SCHEDULE.PHASE_DEPENDANT && world.provider.getMoonPhase(wt) == BloodmoonConfig.SCHEDULE.PHASE_NUM) || (BloodmoonConfig.SCHEDULE.NTH_NIGHT != 0 && nightCounter == 0))
 						{
 							forceBloodMoon = false;
 							setBloodmoon(true);


### PR DESCRIPTION
Added a new setting to change the current phase in which the Bloodmoon will be active. This allows playing with other mods like Nyx, so both moon events are not in the same phase.
